### PR TITLE
Allow respond option to be false

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var UnauthorizedError = AnvilConnect.UnauthorizedError
 function AnvilConnectExpress (options) {
   options = options || {}
   this.client = new AnvilConnect(options)
-  this.respond = options.respond || true
+  this.respond = typeof options.respond === 'undefined' ? true : options.respond
 }
 
 /**


### PR DESCRIPTION
Prior, if `respond` was falsy, the AnvilConnectExpress constructor would ignore its value and instead use `true`. This made it impossible to use `respond` to change the behaviour such that the default error handler would not be used.

This change makes the check more specific by instead checking whether or not `respond` is undefined. If it is, `true` is used as a default just as before. If it is not undefined, then its value is respected.
