### PR TITLE
Refactor verifier, add option to not raise error on missing token

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ authentication/authorization server (based on the
 ### Installation
 
 This library assumes that you have Node.js installed (it's developed and tested
-on Node v4 and above), and are familiar with Express routes and middleware.
+on Node 4 and above), and are familiar with Express routes and middleware.
 To install dependencies:
 
 ```
@@ -42,28 +42,52 @@ var express = require('express')
 var app = express()
 ```
 
-### Authorizing
+### Usage
 
-The Anvil Connect lib for Express allows you to authorize requests from one to 
-multiple endpoints or even the entire server.
+The Anvil Connect lib for Express allows you to require authentication and
+authorization for any requests to any number of Express endpoints (or even
+the entire server).
 
-##### Authorize a single endpoint
+##### Single endpoint
 ```javascript
-app.get('/authenticated', anvil.verifier(), function (req, res, next) {
-  // This endpoint is authenticated...
+app.get('/protected', anvil.verifier(), function (req, res, next) {
+  // This endpoint is authenticated and authorized
 })
 ```
 
-##### Authorize your entire server
+##### All endpoints
 ```javascript
 app.use(anvil.verifier())
 
-app.get('/authenticated', function (req, res, next) {
-  // This endpoint is authenticated...
+app.get('/protected-one', function (req, res, next) {
+  // This endpoint is authenticated and authorized
 })
 
-app.get('/authed', function (req, res, next) {
-  // This endpoint is also authenticated...
+app.get('/protected-two', function (req, res, next) {
+  // This endpoint is also authenticated and authorized
+})
+```
+
+##### Optionally Authenticate
+
+By default, as in the above examples, if an endpoint uses the `verifier()`
+middleware, it will throw an authorization error if an access token is not
+included with that request: `An access token is required`.
+
+However, for some use cases, the access token is optional (but you still want
+to invoke `verifier()` so that the token is parsed, and the credentials are
+added to the `req` object for downstream use. For example, if the resource was 
+set to 'allow anyone to read' by its owner, a request with no  token is 
+acceptable - no error should be raised until the control flow passes to a 
+downstream authorization component.
+
+In this case, set the optional parameter `allowNoToken` to true:
+
+```js
+var verifyOptions = { allowNoToken: true }
+app.get('/maybe-protected', anvil.verifier(verifyOptions), function (req, res, next) {
+  // The verifier parses the access token and adds it to `req`
+  // but does not raise an error if it's missing
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,31 @@
 # Anvil Connect lib for Express
+[![NPM Version](https://img.shields.io/npm/v/anvil-connect-express.svg?style=flat)](https://npm.im/anvil-connect-express)
 [![Build Status](https://travis-ci.org/anvilresearch/connect-express.svg?branch=master)](https://travis-ci.org/anvilresearch/connect-express)
 
-### Configure
+### Overview
 
-Require the project and configure the client with an `issuer`, a `client_id`, and a `client_secret`.
+This is a simple auth middleware for Express.js apps that works with the 
+[Anvil Connect](https://github.com/anvilresearch/connect) 
+authentication/authorization server (based on the 
+[OpenID Connect](http://openid.net/connect/) and OAuth 2 stack), and the 
+[`anvil-connect-nodejs`](https://github.com/anvilresearch/connect-nodejs) client.
+
+### Installation
+
+This library assumes that you have Node.js installed (it's developed and tested
+on Node v4 and above), and are familiar with Express routes and middleware.
+To install dependencies:
+
+```
+npm install
+```
+
+### Configuration
+
+Require the project and configure the client with an `issuer`, a `client_id`, 
+and a `client_secret`. For more information on registering and configuring
+OpenID Connect clients, see the 
+[Anvil Connect Documentation](https://github.com/anvilresearch/connect-docs).
 
 ```javascript
 var AnvilConnect = require('anvil-connect-express')
@@ -20,9 +42,10 @@ var express = require('express')
 var app = express()
 ```
 
-### Authorize
+### Authorizing
 
-The Anvil Connect lib for Express allows you to authorize requests from one to multiple endpoints or even the entire server.
+The Anvil Connect lib for Express allows you to authorize requests from one to 
+multiple endpoints or even the entire server.
 
 ##### Authorize a single endpoint
 ```javascript
@@ -44,9 +67,11 @@ app.get('/authed', function (req, res, next) {
 })
 ```
 
-### Customize
+### Customizations
 
-The Anvil Connect lib for Express allows for some customization. You can authorize with a required scope or even whitelist clients you want to allow by client_id.
+The Anvil Connect lib for Express allows for some customization. You can 
+authorize with a required scope or even whitelist clients you want to allow by 
+`client_id`.
 
 ##### Authorize with a required scope
 
@@ -82,3 +107,15 @@ var authorize = anvil.verifier({
   ]
 })
 ```
+
+### Unit Testing
+
+To run the unit tests after installation:
+
+```
+npm test
+```
+
+### License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ app.get('/maybe-protected', anvil.verifier(verifyOptions), function (req, res, n
 })
 ```
 
+##### Optionally Load User Info
+
+In addition to parsing and verifying the access token, you can ask `verifier()`
+to also load user profile details from the OpenID Provider's `/userinfo` 
+endpoint:
+
+```js
+var verifyOptions = { loadUserInfo: true }
+app.get('/protected', anvil.verifier(verifyOptions), function (req, res, next) {
+  // The verifier parses the access token, and also loads user profile
+})
+```
+
 ### Customizations
 
 The Anvil Connect lib for Express allows for some customization. You can 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ app.get('/protected-two', function (req, res, next) {
 ##### Optionally Authenticate
 
 By default, as in the above examples, if an endpoint uses the `verifier()`
-middleware, it will throw an authorization error if an access token is not
-included with that request: `An access token is required`.
+middleware, it will throw an HTTP 
+[401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1) 
+`An access token is required` error if an access token is not included with that 
+request.
 
-However, for some use cases, the access token is optional (but you still want
+However, for some use cases, the access token is optional, but you still want
 to invoke `verifier()` so that the token is parsed, and the credentials are
 added to the `req` object for downstream use. For example, if the resource was 
-set to 'allow anyone to read' by its owner, a request with no  token is 
+set to 'allow anyone to read' by its owner, a request with no token is 
 acceptable - no error should be raised until the control flow passes to a 
 downstream authorization component.
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,23 @@
 /**
+ * Simple auth middleware for Express.js apps that works with Anvil Connect
+ * server and node client.
+ * @module anvil-connect-express
+ */
+module.exports = AnvilConnectExpress
+
+/**
  * Module dependencies
  */
-
 var AnvilConnect = require('anvil-connect-nodejs')
 var UnauthorizedError = AnvilConnect.UnauthorizedError
 
 /**
- * Constructor
+ * @class AnvilConnectExpress
+ * @constructor
+ * @param [options] {Object} Options hashmap (passed through to the Client)
+ * @param [options.respond=true] {Boolean} Whether to write an error to the
+ *   response object (passes it downstream if set to false)
  */
-
 function AnvilConnectExpress (options) {
   options = options || {}
   this.client = new AnvilConnect(options)
@@ -16,10 +25,14 @@ function AnvilConnectExpress (options) {
 }
 
 /**
- * Next
+ * Returns an Express handler for http error responses.
+ * @method errorHandler
+ * @param req {IncomingMessage} Express request object
+ * @param res {ServerResponse} Express response object
+ * @param next {Function} Express next() callback
+ * @return {Function} Error handler
  */
-
-function handler (req, res, next) {
+function errorHandler (req, res, next) {
   var self = this
 
   return function (err) {
@@ -35,125 +48,155 @@ function handler (req, res, next) {
     }
   }
 }
-
-AnvilConnectExpress.prototype.handler = handler
+AnvilConnectExpress.prototype.errorHandler = errorHandler
 
 /**
- * Verify Middleware
+ * Extracts and returns an OIDC AccessToken. First looks in the auth
+ * header, then tries the query params in the request URI, and lastly
+ * looks in the request body (for a form-encoded token).
+ * @method extractToken
+ * @param req {IncomingMessage} Express request object
+ * @param nextError {Function} Error handler
+ * @throws {UnauthorizedError} HTTP 400 error on invalid auth headers
+ * @returns {AccessToken} JWT Access Token
  */
+function extractToken (req, nextError) {
+  // Check for an access token in the Authorization header
+  if (req.headers && req.headers.authorization) {
+    var components = req.headers.authorization.split(' ')
+    var scheme = components[0]
+    var credentials = components[1]
+    var accessToken
 
+    if (components.length !== 2) {
+      return nextError(new UnauthorizedError({
+        error: 'invalid_request',
+        error_description: 'Invalid authorization header',
+        statusCode: 400
+      }))
+    }
+    if (scheme !== 'Bearer') {
+      return nextError(new UnauthorizedError({
+        error: 'invalid_request',
+        error_description: 'Invalid authorization scheme',
+        statusCode: 400
+      }))
+    }
+    accessToken = credentials
+  }
+
+  // Check for an access token in the request URI
+  if (req.query && req.query.access_token) {
+    if (accessToken) {
+      return nextError(new UnauthorizedError({
+        error: 'invalid_request',
+        error_description: 'Multiple authentication methods',
+        statusCode: 400
+      }))
+    }
+    accessToken = req.query.access_token
+  }
+
+  // Check for an access token in the request body
+  if (req.body && req.body.access_token) {
+    if (accessToken) {
+      return nextError(new UnauthorizedError({
+        error: 'invalid_request',
+        error_description: 'Multiple authentication methods',
+        statusCode: 400
+      }))
+    }
+    if (req.headers &&
+      req.headers['content-type'] !== 'application/x-www-form-urlencoded') {
+      return nextError(new UnauthorizedError({
+        error: 'invalid_request',
+        error_description: 'Invalid content-type',
+        statusCode: 400
+      }))
+    }
+    accessToken = req.body.access_token
+  }
+  return accessToken
+}
+AnvilConnectExpress.prototype.extractToken = extractToken
+
+/**
+ * Returns an Express.js middleware handler for verifying OpenID Connect/OAuth 2
+ * access tokens.
+ * @method verifier
+ * @param [options] {Object} Options hashmap for overriding OIDC client options
+ *   (the client's id, issuer etc should already be set at this point)
+ * @param [options.failMissingToken=false] {Boolean}
+ * @param [options.client_id] {String}
+ * @param [options.client_secret] {String}
+ * @param [options.clients] {Array<String>} Whitelist of client ids (restrict
+ *   verification only to these clients).
+ * @param [options.issuer] {String} OpenID Connect provider url
+ * @param [options.key] {String} JWK key
+ * @param [options.scope] {String}
+ * @throws {UnauthorizedError} HTTP 400 error on invalid auth headers
+ * @return {Function} Express middleware handler function
+ */
 function verifier (options) {
+  options = options || {}
   var self = this
 
   return function (req, res, next) {
-    var accessToken
-    var nexter = self.handler(req, res, next)
-
-    // Check for an access token in the Authorization header
-    if (req.headers && req.headers.authorization) {
-      var components = req.headers.authorization.split(' ')
-      var scheme = components[0]
-      var credentials = components[1]
-
-      if (components.length !== 2) {
-        return nexter(new UnauthorizedError({
-          error: 'invalid_request',
-          error_description: 'Invalid authorization header',
-          statusCode: 400
-        }))
-      }
-
-      if (scheme !== 'Bearer') {
-        return nexter(new UnauthorizedError({
-          error: 'invalid_request',
-          error_description: 'Invalid authorization scheme',
-          statusCode: 400
-        }))
-      }
-
-      accessToken = credentials
-    }
-
-    // Check for an access token in the request URI
-    if (req.query && req.query.access_token) {
-      if (accessToken) {
-        return nexter(new UnauthorizedError({
-          error: 'invalid_request',
-          error_description: 'Multiple authentication methods',
-          statusCode: 400
-        }))
-      }
-
-      accessToken = req.query.access_token
-    }
-
-    // Check for an access token in the request body
-    if (req.body && req.body.access_token) {
-      if (accessToken) {
-        return nexter(new UnauthorizedError({
-          error: 'invalid_request',
-          error_description: 'Multiple authentication methods',
-          statusCode: 400
-        }))
-      }
-
-      if (req.headers &&
-        req.headers['content-type'] !== 'application/x-www-form-urlencoded') {
-        return nexter(new UnauthorizedError({
-          error: 'invalid_request',
-          error_description: 'Invalid content-type',
-          statusCode: 400
-        }))
-      }
-
-      accessToken = req.body.access_token
-    }
-
-    function invokeVerification () {
-      self.client.verify(accessToken, options)
-        .then(function (accessTokenClaims) {
-          req.accessToken = accessToken
-          req.accessTokenClaims = accessTokenClaims
-          next()
-        })
-        .catch(function (err) {
-          nexter(err)
-        })
-    }
+    var nextError = self.errorHandler(req, res, next)
+    var accessToken = self.extractToken(req, nextError)
 
     // Missing access token
     if (!accessToken) {
-      return nexter(new UnauthorizedError({
+      return nextError(new UnauthorizedError({
         realm: 'user',
         error: 'invalid_request',
         error_description: 'An access token is required',
         statusCode: 400
       }))
-
-    // Access token found
-    } else {
+    } else { // Access token found
       // If JWKs are not set, attempt to retrieve them first
       if (!self.client.jwks) {
-        self.client.discover().then(function () {
-          return self.client.getJWKs()
-        })
-        // then verify the token and carry on
-        .then(invokeVerification)
-        .catch(function (err) {
-          nexter(err)
-        })
+        self.client.discover()
+          .then(function () {
+            return self.client.getJWKs()
+          })
+          // then verify the token and carry on
+          .then(function () {
+            self.verifyToken(req, accessToken, next, nextError, options)
+          })
+          .catch(function (err) {
+            nextError(err)
+          })
       // otherwise, verify the token right away
       } else {
-        invokeVerification()
+        self.verifyToken(req, accessToken, next, nextError, options)
       }
     }
   }
 }
-
 AnvilConnectExpress.prototype.verifier = verifier
 
 /**
- * Export
+ * Verifies the access token and inserts it into the `req` object for downstream
+ * use.
+ * @method verifyToken
+ * @param req {IncomingMessage} Express request object
+ * @param accessToken {AccessToken} JWT AccessToken for OpenID Connect
+ * @param next {Function} Express next() callback
+ * @param nextError {Function} Error handler
+ * @param options {Object} Options hashmap (see option param docs for
+ *   the `verifier()` method above)
  */
+function verifyToken (req, accessToken, next, nextError, options) {
+  this.client.verify(accessToken, options)
+    .then(function (accessTokenClaims) {
+      req.accessToken = accessToken
+      req.accessTokenClaims = accessTokenClaims
+      next()
+    })
+    .catch(function (err) {
+      nextError(err)
+    })
+}
+AnvilConnectExpress.prototype.verifyToken = verifyToken
 
-module.exports = AnvilConnectExpress

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var UnauthorizedError = AnvilConnect.UnauthorizedError
 function AnvilConnectExpress (options) {
   options = options || {}
   this.client = new AnvilConnect(options)
-  this.respond = options.respond || true
+  this.respond = 'respond' in options ? options.respond : true
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -126,7 +126,9 @@ AnvilConnectExpress.prototype.extractToken = extractToken
  * @method verifier
  * @param [options] {Object} Options hashmap for overriding OIDC client options
  *   (the client's id, issuer etc should already be set at this point)
- * @param [options.failMissingToken=false] {Boolean}
+ * @param [options.allowNoToken=false] {Boolean} Do not raise 'Access to token
+ *   is required' error if set to true. Useful for access to authenticated
+ *   but allow-anyone resources.
  * @param [options.client_id] {String}
  * @param [options.client_secret] {String}
  * @param [options.clients] {Array<String>} Whitelist of client ids (restrict
@@ -139,6 +141,7 @@ AnvilConnectExpress.prototype.extractToken = extractToken
  */
 function verifier (options) {
   options = options || {}
+  var allowNoToken = options.allowNoToken || false
   var self = this
 
   return function (req, res, next) {
@@ -146,7 +149,7 @@ function verifier (options) {
     var accessToken = self.extractToken(req, nextError)
 
     // Missing access token
-    if (!accessToken) {
+    if (!accessToken && !allowNoToken) {
       return nextError(new UnauthorizedError({
         realm: 'user',
         error: 'invalid_request',
@@ -184,7 +187,7 @@ AnvilConnectExpress.prototype.verifier = verifier
  * @param accessToken {AccessToken} JWT AccessToken for OpenID Connect
  * @param next {Function} Express next() callback
  * @param nextError {Function} Error handler
- * @param options {Object} Options hashmap (see option param docs for
+ * @param [options] {Object} Options hashmap (see option param docs for
  *   the `verifier()` method above)
  */
 function verifyToken (req, accessToken, next, nextError, options) {

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ AnvilConnectExpress.prototype.errorHandler = errorHandler
  * @param req {IncomingMessage} Express request object
  * @param nextError {Function} Error handler
  * @throws {UnauthorizedError} HTTP 400 error on invalid auth headers
- * @returns {AccessToken} JWT Access Token
+ * @return {AccessToken} JWT Access Token
  */
 function extractToken (req, nextError) {
   // Check for an access token in the Authorization header
@@ -204,6 +204,7 @@ AnvilConnectExpress.prototype.verifier = verifier
  * @param nextError {Function} Error handler
  * @param [options] {Object} Options hashmap (see option param docs for
  *   the `verifier()` method above)
+ * @throws {UnauthorizedError} HTTP 401 or 403 errors thrown by client.verify()
  */
 function verifyToken (req, accessToken, next, nextError, options) {
   return this.client.verify(accessToken, options)

--- a/index.js
+++ b/index.js
@@ -138,7 +138,8 @@ AnvilConnectExpress.prototype.extractToken = extractToken
  * @param [options.issuer] {String} OpenID Connect provider url
  * @param [options.key] {String} JWK key
  * @param [options.scope] {String}
- * @throws {UnauthorizedError} HTTP 400 error on invalid auth headers
+ * @throws {UnauthorizedError} HTTP 400 error on invalid auth headers, or an
+ *   HTTP 401 Unauthorized error for a missing access token.
  * @return {Function} Express middleware handler function
  */
 function verifier (options) {
@@ -157,7 +158,7 @@ function verifier (options) {
         realm: 'user',
         error: 'invalid_request',
         error_description: 'An access token is required',
-        statusCode: 400
+        statusCode: 401
       }))
     } else { // Access token found
       // If JWKs are not set, attempt to retrieve them first

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anvil-connect-express",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Anvil Connect client for Express",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anvil-connect-express",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Anvil Connect client for Express",
   "main": "index.js",
   "scripts": {

--- a/test/connectExpressTest.coffee
+++ b/test/connectExpressTest.coffee
@@ -179,8 +179,8 @@ describe 'Anvil Connect for Express', ->
         verifier = anvil.verifier()
         verifier req, res, next
 
-      it 'should respond 400', ->
-        status.should.have.been.calledWith 400
+      it 'should respond 401', ->
+        status.should.have.been.calledWith 401
 
       it 'should respond with an error', ->
         json.should.have.been.calledWith sinon.match({


### PR DESCRIPTION
- Expand the README, add links to parent projects, add npm badge
- Refactor the `verifier()` method, move token extraction to its own method, move inline `invokeVerification()` function to its own method
- Add `allowNoToken` option to not raise an error on missing token
