### PR TITLE
Fix PR #6 (bump connect-nodejs dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "anvil-connect-nodejs": "^0.3.0"
+    "anvil-connect-nodejs": "^0.4.0"
   }
 }


### PR DESCRIPTION
PR #6 depended on a simultaneous PR to connect-nodejs (which was just published as v0.4.0).
Bumping the dependency to reflect this.
